### PR TITLE
Add more caching to macOS runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
         
-      - name: Cache Build
+      - name: Cache macOS Build
         id: cache-build
         uses: actions/cache@v2
         with:
           path: |
             $GITHUB_WORKSPACE/SourcePackages
+            $GITHUB_WORKSPACE/macos_build
             /Users/runner/Library/Developer/Xcode/DerivedData
           key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
@@ -69,12 +70,13 @@ jobs:
           bsdtar --strip-components=1 -xf master.zip --directory $GITHUB_WORKSPACE/theos/sdks
           rm -f master.zip
 
-      - name: Cache Build
+      - name: Cache iOS Build
         id: cache-build
         uses: actions/cache@v2
         with:
           path: |
             $GITHUB_WORKSPACE/SourcePackages
+            $GITHUB_WORKSPACE/ios_build
             /Users/runner/Library/Developer/Xcode/DerivedData
           key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,22 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v2
+        
+      - name: Cache Build
+        id: cache-build
+        uses: actions/cache@v2
+        with:
+          path: |
+            $GITHUB_WORKSPACE/SourcePackages
+            /Users/runner/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-build
 
       - name: Build macOS
         run: make macos
 
-      - name: Archive artifacts
+      - name: Archive Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: macOS-build
@@ -27,17 +36,25 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: prepare environment
+      - name: Prepare Environment
         run: |
           brew install ldid make
           echo "THEOS=$GITHUB_WORKSPACE/theos" >> $GITHUB_ENV
           PATH="/usr/local/opt/make/libexec/gnubin:$PATH" >> $GITHUB_ENV
           echo "Succesfully installed tools!"
+ 
+      - name: Cache Theos
+        id: cache-theos
+        uses: actions/cache@v2
+        with:
+          path: theos
+          key: ${{ runner.os }}-theos
 
       - name: Setup Theos
+        if: steps.cache-theos.outputs.cache-hit != 'true'
         uses: actions/checkout@main
         with:
           repository: theos/theos
@@ -46,18 +63,29 @@ jobs:
           submodules: recursive
 
       - name: Download SDKs
+        if: steps.cache-theos.outputs.cache-hit != 'true'
         run: |
           curl -LO https://github.com/xybp888/iOS-SDKs/archive/master.zip
           bsdtar --strip-components=1 -xf master.zip --directory $GITHUB_WORKSPACE/theos/sdks
           rm -f master.zip
+
+      - name: Cache Build
+        id: cache-build
+        uses: actions/cache@v2
+        with:
+          path: |
+            $GITHUB_WORKSPACE/SourcePackages
+            /Users/runner/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-build
 
       - name: Build iOS
         run: |
           export THEOS=$GITHUB_WORKSPACE/theos
           make ios
 
-      - name: Archive artifacts
+      - name: Archive Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: iOS-build
           path: archive
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           path: |
             $GITHUB_WORKSPACE/SourcePackages
             /Users/runner/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-build
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
       - name: Build macOS
         run: make macos
@@ -76,7 +76,7 @@ jobs:
           path: |
             $GITHUB_WORKSPACE/SourcePackages
             /Users/runner/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-build
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
       - name: Build iOS
         run: |


### PR DESCRIPTION
Adds more caching of build dir and Theos sdks, results are slightly faster although still inconsistent due to the runner being slow for some reason. Should be about 11 min per build average. 